### PR TITLE
oraclejdk7 no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: java
 
 jdk:
- - oraclejdk7
+ - oraclejdk8
  - openjdk7
  
 script: mvn clean install


### PR DESCRIPTION
Jdk7 broken on container based trusty (see https://github.com/travis-ci/travis-ci/issues/7019)